### PR TITLE
Fix Makefile so that make(1) can actually understand it.

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,16 +1,8 @@
-CXX := clang++
-CXXFLAGS := -Wall -Wextra -pedantic -std=c++11
+CXXFLAGS= -Wall -Wextra -pedantic -std=c++11 -I.. -I/usr/local/include
+CXXFLAGS+= $$(sh ./is_mac.sh)
+CPPFLAGS= -I.. -I/usr/local/include
 
-KERNEL := $(shell uname -s)
-ifeq ($(KERNEL),Darwin)
-ifeq ($(CXX),clang++)
-	CXXFLAGS += -stdlib=libc++
-endif
-endif
-
-LINK.o = $(LINK.cc)
-
-CPPFLAGS := -I".."
+include .depend
 
 TESTS = \
 		testchain \
@@ -32,7 +24,13 @@ TESTS = \
 		testcombinations \
 		testpowerset
 
-all: $(TESTS)
+
+all: .depend $(TESTS)
+
+.depend: /dev/null
+	for a in *.cpp; do ($(CC) $(CPPFLAGS) -MM $$a >> .depend); done
 
 clean:
-	rm -f *.o $(TESTS)
+	rm -f *.o $(TESTS) .depend
+	touch .depend
+# DO NOT DELETE

--- a/tests/is_mac.sh
+++ b/tests/is_mac.sh
@@ -1,0 +1,4 @@
+if [ $(uname -s) = "Darwin" ]
+then
+	printf "-std=libc++";
+fi


### PR DESCRIPTION
There is a nasty hack here to test for mac and -std=libc++.
There is one bug here: .depend does not depend on the .cpp files.
This entire file should be converted to cmake.

Also, I am tired, and the .depend generation is buggy (make must be run twice for it be correct).  I will try to convert this to autojunk or cmake at some point 
