### PR TITLE
Fix sconstruct:

### DIFF
--- a/tests/SConstruct
+++ b/tests/SConstruct
@@ -24,9 +24,9 @@ progs = Split( '''
         filterfalse
         ''')
 
-cxx = 'clang++'
-cxx_flags = ' -Wall -Wextra -pedantic -std=c++11 '
-ldflags = ''
+cxx = 'c++'
+cxx_flags = ' -Wall -Wextra -pedantic -std=c++11 -I/usr/local/include'
+ldflags = ' -L/usr/local/lib'
 
 # if on MAC, needs the linker flag for -stdlib=libc++
 if platform.system() == 'Darwin':


### PR DESCRIPTION
'c++' is the C++ compiler.  There is no reason to assume either clang++
or g++.

/usr/local/include must be included on modern unixes to use boost.
