### PR TITLE
Replace unique_ptr with optional

### DIFF
--- a/accumulate.hpp
+++ b/accumulate.hpp
@@ -56,23 +56,8 @@ class iter::impl::Accumulator {
                        ? std::nullopt
                        : std::make_optional<AccumVal>(*sub_iter_)} {}
 
-    Iterator(const Iterator& other)
-        : sub_iter_{other.sub_iter_},
-          sub_end_{other.sub_end_},
-          accumulate_func_{other.accumulate_func_},
-          acc_val_{other.acc_val_} {}
-
-    Iterator& operator=(const Iterator& other) {
-      if (this == &other) {
-        return *this;
-      }
-      sub_iter_ = other.sub_iter_;
-      sub_end_ = other.sub_end_;
-      accumulate_func_ = other.accumulate_func_;
-      acc_val_ = other.acc_val_;
-      return *this;
-    }
-
+    Iterator(const Iterator& other) = default;
+    Iterator& operator=(const Iterator& other) = default;
     Iterator(Iterator&&) = default;
     Iterator& operator=(Iterator&&) = default;
 

--- a/accumulate.hpp
+++ b/accumulate.hpp
@@ -66,7 +66,7 @@ class iter::impl::Accumulator {
     }
 
     const AccumVal* operator->() const {
-      return acc_val_.operator->();
+      return &*acc_val_;
     }
 
     Iterator& operator++() {

--- a/accumulate.hpp
+++ b/accumulate.hpp
@@ -6,7 +6,7 @@
 
 #include <functional>
 #include <iterator>
-#include <memory>
+#include <optional>
 #include <type_traits>
 #include <utility>
 
@@ -43,7 +43,7 @@ class iter::impl::Accumulator {
     IteratorWrapper<Container> sub_iter_;
     IteratorWrapper<Container> sub_end_;
     AccumulateFunc* accumulate_func_;
-    std::unique_ptr<AccumVal> acc_val_;
+    std::optional<AccumVal> acc_val_;
 
    public:
     Iterator(IteratorWrapper<Container>&& sub_iter,
@@ -52,14 +52,15 @@ class iter::impl::Accumulator {
           sub_end_{std::move(sub_end)},
           accumulate_func_(&accumulate_fun),
           // only get first value if not an end iterator
-          acc_val_{
-              !(sub_iter_ != sub_end_) ? nullptr : new AccumVal(*sub_iter_)} {}
+          acc_val_{!(sub_iter_ != sub_end_)
+                       ? std::nullopt
+                       : std::make_optional<AccumVal>(*sub_iter_)} {}
 
     Iterator(const Iterator& other)
         : sub_iter_{other.sub_iter_},
           sub_end_{other.sub_end_},
           accumulate_func_{other.accumulate_func_},
-          acc_val_{other.acc_val_ ? new AccumVal(*other.acc_val_) : nullptr} {}
+          acc_val_{other.acc_val_} {}
 
     Iterator& operator=(const Iterator& other) {
       if (this == &other) {
@@ -68,7 +69,7 @@ class iter::impl::Accumulator {
       sub_iter_ = other.sub_iter_;
       sub_end_ = other.sub_end_;
       accumulate_func_ = other.accumulate_func_;
-      acc_val_.reset(other.acc_val_ ? new AccumVal(*other.acc_val_) : nullptr);
+      acc_val_ = other.acc_val_;
       return *this;
     }
 
@@ -80,7 +81,7 @@ class iter::impl::Accumulator {
     }
 
     const AccumVal* operator->() const {
-      return acc_val_.get();
+      return acc_val_.operator->();
     }
 
     Iterator& operator++() {

--- a/chain.hpp
+++ b/chain.hpp
@@ -209,25 +209,8 @@ class iter::impl::ChainedFromIterable {
                          std::nullopt
                          : std::make_optional<SubIter>(get_end(*top_iter))} {}
 
-    Iterator(const Iterator& other)
-        : top_level_iter_{other.top_level_iter_},
-          top_level_end_{other.top_level_end_},
-          sub_iter_p_{other.sub_iter_p_},
-          sub_end_p_{other.sub_end_p_} {}
-
-    Iterator& operator=(const Iterator& other) {
-      if (this == &other) {
-        return *this;
-      }
-
-      top_level_iter_ = other.top_level_iter_;
-      top_level_end_ = other.top_level_end_;
-      sub_iter_p_ = other.sub_iter_p_;
-      sub_end_p_ = other.sub_end_p_;
-
-      return *this;
-    }
-
+    Iterator(const Iterator& other) = default;
+    Iterator& operator=(const Iterator& other) = default;
     Iterator(Iterator&&) = default;
     Iterator& operator=(Iterator&&) = default;
     ~Iterator() = default;

--- a/chain.hpp
+++ b/chain.hpp
@@ -7,7 +7,7 @@
 
 #include <array>
 #include <iterator>
-#include <memory>
+#include <optional>
 #include <tuple>
 #include <type_traits>
 #include <utility>
@@ -192,24 +192,8 @@ class iter::impl::ChainedFromIterable {
 
     IteratorWrapper<Container> top_level_iter_;
     IteratorWrapper<Container> top_level_end_;
-    std::unique_ptr<SubIter> sub_iter_p_;
-    std::unique_ptr<SubIter> sub_end_p_;
-
-    static std::unique_ptr<SubIter> clone_sub_pointer(const SubIter* sub_iter) {
-      return sub_iter ? std::make_unique<SubIter>(*sub_iter) : nullptr;
-    }
-
-    bool sub_iters_differ(const Iterator& other) const {
-      if (sub_iter_p_ == other.sub_iter_p_) {
-        return false;
-      }
-      if (sub_iter_p_ == nullptr || other.sub_iter_p_ == nullptr) {
-        // since the first check tests if they're the same,
-        // this will return if only one is nullptr
-        return true;
-      }
-      return *sub_iter_p_ != *other.sub_iter_p_;
-    }
+    std::optional<SubIter> sub_iter_p_;
+    std::optional<SubIter> sub_end_p_;
 
    public:
     Iterator(IteratorWrapper<Container>&& top_iter,
@@ -218,18 +202,18 @@ class iter::impl::ChainedFromIterable {
           top_level_end_{std::move(top_end)},
           sub_iter_p_{!(top_iter != top_end)
                           ?  // iter == end ?
-                          nullptr
-                          : std::make_unique<SubIter>(get_begin(*top_iter))},
+                          std::nullopt
+                          : std::make_optional<SubIter>(get_begin(*top_iter))},
           sub_end_p_{!(top_iter != top_end)
                          ?  // iter == end ?
-                         nullptr
-                         : std::make_unique<SubIter>(get_end(*top_iter))} {}
+                         std::nullopt
+                         : std::make_optional<SubIter>(get_end(*top_iter))} {}
 
     Iterator(const Iterator& other)
         : top_level_iter_{other.top_level_iter_},
           top_level_end_{other.top_level_end_},
-          sub_iter_p_{clone_sub_pointer(other.sub_iter_p_.get())},
-          sub_end_p_{clone_sub_pointer(other.sub_end_p_.get())} {}
+          sub_iter_p_{other.sub_iter_p_},
+          sub_end_p_{other.sub_end_p_} {}
 
     Iterator& operator=(const Iterator& other) {
       if (this == &other) {
@@ -238,8 +222,8 @@ class iter::impl::ChainedFromIterable {
 
       top_level_iter_ = other.top_level_iter_;
       top_level_end_ = other.top_level_end_;
-      sub_iter_p_ = clone_sub_pointer(other.sub_iter_p_.get());
-      sub_end_p_ = clone_sub_pointer(other.sub_end_p_.get());
+      sub_iter_p_ = other.sub_iter_p_;
+      sub_end_p_ = other.sub_end_p_;
 
       return *this;
     }
@@ -253,8 +237,8 @@ class iter::impl::ChainedFromIterable {
       if (!(*sub_iter_p_ != *sub_end_p_)) {
         ++top_level_iter_;
         if (top_level_iter_ != top_level_end_) {
-          sub_iter_p_ = std::make_unique<SubIter>(get_begin(*top_level_iter_));
-          sub_end_p_ = std::make_unique<SubIter>(get_end(*top_level_iter_));
+          sub_iter_p_ = get_begin(*top_level_iter_);
+          sub_end_p_ = get_end(*top_level_iter_);
         } else {
           sub_iter_p_.reset();
           sub_end_p_.reset();
@@ -271,7 +255,7 @@ class iter::impl::ChainedFromIterable {
 
     bool operator!=(const Iterator& other) const {
       return top_level_iter_ != other.top_level_iter_
-             || sub_iters_differ(other);
+             || sub_iter_p_ != other.sub_iter_p_;
     }
 
     bool operator==(const Iterator& other) const {

--- a/groupby.hpp
+++ b/groupby.hpp
@@ -8,6 +8,7 @@
 
 #include <iterator>
 #include <memory>
+#include <optional>
 #include <type_traits>
 #include <utility>
 
@@ -58,7 +59,7 @@ class iter::impl::GroupProducer {
     IteratorWrapper<Container> sub_end_;
     Holder item_;
     KeyFunc* key_func_;
-    std::unique_ptr<KeyGroupPair> current_key_group_pair_;
+    std::optional<KeyGroupPair> current_key_group_pair_;
 
    public:
     Iterator(IteratorWrapper<Container>&& sub_iter,
@@ -101,7 +102,7 @@ class iter::impl::GroupProducer {
 
     KeyGroupPair* operator->() {
       set_key_group_pair();
-      return current_key_group_pair_.get();
+      return current_key_group_pair_.operator->();
     }
 
     Iterator& operator++() {
@@ -153,7 +154,7 @@ class iter::impl::GroupProducer {
 
     void set_key_group_pair() {
       if (!current_key_group_pair_) {
-        current_key_group_pair_ = std::make_unique<KeyGroupPair>(
+        current_key_group_pair_.emplace(
             (*key_func_)(item_.get()), Group{*this, next_key()});
       }
     }

--- a/groupby.hpp
+++ b/groupby.hpp
@@ -102,7 +102,7 @@ class iter::impl::GroupProducer {
 
     KeyGroupPair* operator->() {
       set_key_group_pair();
-      return current_key_group_pair_.operator->();
+      return &*current_key_group_pair_;
     }
 
     Iterator& operator++() {

--- a/internal/iterbase.hpp
+++ b/internal/iterbase.hpp
@@ -10,7 +10,7 @@
 #include <cstddef>
 #include <functional>
 #include <iterator>
-#include <memory>
+#include <optional>
 #include <tuple>
 #include <type_traits>
 #include <utility>
@@ -225,7 +225,7 @@ namespace iter {
       // it could still be an rvalue reference
       using TPlain = std::remove_reference_t<T>;
 
-      std::unique_ptr<TPlain> item_p;
+      std::optional<TPlain> item_p;
 
      public:
       using reference = TPlain&;
@@ -233,13 +233,10 @@ namespace iter {
 
       DerefHolder() = default;
 
-      DerefHolder(const DerefHolder& other)
-          : item_p{other.item_p ? std::make_unique<TPlain>(*other.item_p)
-                                : nullptr} {}
+      DerefHolder(const DerefHolder& other) : item_p{other.item_p} {}
 
       DerefHolder& operator=(const DerefHolder& other) {
-        this->item_p =
-            other.item_p ? std::make_unique<TPlain>(*other.item_p) : nullptr;
+        this->item_p = other.item_p;
         return *this;
       }
 
@@ -256,7 +253,7 @@ namespace iter {
       }
 
       void reset(T&& item) {
-        item_p = std::make_unique<TPlain>(std::move(item));
+        item_p = std::move(item);
       }
 
       explicit operator bool() const {

--- a/internal/iterbase.hpp
+++ b/internal/iterbase.hpp
@@ -233,13 +233,8 @@ namespace iter {
 
       DerefHolder() = default;
 
-      DerefHolder(const DerefHolder& other) : item_p{other.item_p} {}
-
-      DerefHolder& operator=(const DerefHolder& other) {
-        this->item_p = other.item_p;
-        return *this;
-      }
-
+      DerefHolder(const DerefHolder& other) = default;
+      DerefHolder& operator=(const DerefHolder& other) = default;
       DerefHolder(DerefHolder&&) = default;
       DerefHolder& operator=(DerefHolder&&) = default;
       ~DerefHolder() = default;


### PR DESCRIPTION
std::unique_ptr was used in DerefHolder, Accumulator, Chain and GroupBy to store optional values. As of std17 we can use std::optional to store those values instead of storing them in std::unique_ptr.  That change should improve performance of cppitertools because we can get rid of heap allocations done by std::unique_ptr.

Because of the way std::optional operators are implemented I also managed to delete some convenience functions in chain.hpp