### PR TITLE
Make index and element public in enumerate

### DIFF
--- a/enumerate.hpp
+++ b/enumerate.hpp
@@ -22,6 +22,8 @@ namespace iter {
     class EnumIterYield : public EnumBasePair<Index, Elem> {
       using BasePair = EnumBasePair<Index, Elem>;
       using BasePair::BasePair;
+
+     public:
       typename BasePair::first_type& index = BasePair::first;
       typename BasePair::second_type& element = BasePair::second;
     };


### PR DESCRIPTION
enumerate_examples doesn't compile with index and element being private. On master branch those fields already are public.