### PR TITLE
Remove use of std::iterator

### DIFF
--- a/accumulate.hpp
+++ b/accumulate.hpp
@@ -39,7 +39,7 @@ class iter::impl::Accumulator {
   Accumulator(Accumulator&&) = default;
 
   template <typename ContainerT>
-  class Iterator : public std::iterator<std::input_iterator_tag, AccumVal> {
+  class Iterator {
    private:
     template <typename>
     friend class Iterator;
@@ -49,6 +49,12 @@ class iter::impl::Accumulator {
     std::unique_ptr<AccumVal> acc_val_;
 
    public:
+    using iterator_category = std::input_iterator_tag;
+    using value_type = AccumVal;
+    using difference_type = std::ptrdiff_t;
+    using pointer = value_type*;
+    using reference = value_type&;
+
     Iterator(IteratorWrapper<ContainerT>&& sub_iter,
         IteratorWrapper<ContainerT>&& sub_end, AccumulateFunc& accumulate_fun)
         : sub_iter_{std::move(sub_iter)},

--- a/chain.hpp
+++ b/chain.hpp
@@ -100,8 +100,7 @@ class iter::impl::Chained {
   Chained(Chained&&) = default;
 
   template <typename TupTypeT>
-  class Iterator : public std::iterator<std::input_iterator_tag,
-                       typename IteratorData<TupTypeT>::TraitsValue> {
+  class Iterator {
    private:
     using IterData = IteratorData<TupTypeT>;
     std::size_t index_;
@@ -116,6 +115,12 @@ class iter::impl::Chained {
     }
 
    public:
+    using iterator_category = std::input_iterator_tag;
+    using value_type = typename IteratorData<TupTypeT>::TraitsValue;
+    using difference_type = std::ptrdiff_t;
+    using pointer = value_type*;
+    using reference = value_type&;
+
     Iterator(std::size_t i, typename IterData::IterTupType&& iters,
         typename IterData::IterTupType&& ends)
         : index_{i}, iters_(std::move(iters)), ends_(std::move(ends)) {
@@ -224,8 +229,7 @@ class iter::impl::ChainedFromIterable {
  public:
   ChainedFromIterable(ChainedFromIterable&&) = default;
   template <typename ContainerT>
-  class Iterator : public std::iterator<std::input_iterator_tag,
-                       iterator_traits_deref<iterator_deref<ContainerT>>> {
+  class Iterator {
    private:
     template <typename>
     friend class Iterator;
@@ -257,6 +261,12 @@ class iter::impl::ChainedFromIterable {
     }
 
    public:
+    using iterator_category = std::input_iterator_tag;
+    using value_type = iterator_traits_deref<iterator_deref<ContainerT>>;
+    using difference_type = std::ptrdiff_t;
+    using pointer = value_type*;
+    using reference = value_type&;
+
     Iterator(IteratorWrapper<ContainerT>&& top_iter,
         IteratorWrapper<ContainerT>&& top_end)
         : top_level_iter_{std::move(top_iter)},

--- a/chunked.hpp
+++ b/chunked.hpp
@@ -41,8 +41,7 @@ class iter::impl::Chunker {
  public:
   Chunker(Chunker&&) = default;
   template <typename ContainerT>
-  class Iterator
-      : public std::iterator<std::input_iterator_tag, DerefVec<ContainerT>> {
+  class Iterator {
    private:
     template <typename>
     friend class Iterator;
@@ -66,6 +65,12 @@ class iter::impl::Chunker {
     }
 
    public:
+    using iterator_category = std::input_iterator_tag;
+    using value_type = DerefVec<ContainerT>;
+    using difference_type = std::ptrdiff_t;
+    using pointer = value_type*;
+    using reference = value_type&;
+
     Iterator(IteratorWrapper<ContainerT>&& sub_iter,
         IteratorWrapper<ContainerT>&& sub_end, std::size_t s)
         : sub_iter_{std::move(sub_iter)},

--- a/combinations.hpp
+++ b/combinations.hpp
@@ -37,8 +37,7 @@ class iter::impl::Combinator {
  public:
   Combinator(Combinator&&) = default;
   template <typename ContainerT>
-  class Iterator : public std::iterator<std::input_iterator_tag,
-                       CombIteratorDeref<ContainerT>> {
+  class Iterator {
    private:
     template <typename>
     friend class Iterator;
@@ -48,6 +47,12 @@ class iter::impl::Combinator {
     int steps_{};
 
    public:
+    using iterator_category = std::input_iterator_tag;
+    using value_type = CombIteratorDeref<ContainerT>;
+    using difference_type = std::ptrdiff_t;
+    using pointer = value_type*;
+    using reference = value_type&;
+
     Iterator(ContainerT& container, std::size_t n)
         : container_p_{&container}, indices_{n} {
       if (n == 0) {

--- a/combinations_with_replacement.hpp
+++ b/combinations_with_replacement.hpp
@@ -37,8 +37,7 @@ class iter::impl::CombinatorWithReplacement {
  public:
   CombinatorWithReplacement(CombinatorWithReplacement&&) = default;
   template <typename ContainerT>
-  class Iterator : public std::iterator<std::input_iterator_tag,
-                       CombIteratorDeref<ContainerT>> {
+  class Iterator {
    private:
     template <typename>
     friend class Iterator;
@@ -48,6 +47,12 @@ class iter::impl::CombinatorWithReplacement {
     int steps_;
 
    public:
+    using iterator_category = std::input_iterator_tag;
+    using value_type = CombIteratorDeref<ContainerT>;
+    using difference_type = std::ptrdiff_t;
+    using pointer = value_type*;
+    using reference = value_type&;
+
     Iterator(ContainerT& in_container, std::size_t n)
         : container_p_{&in_container},
           indices_(n, get_begin(in_container)),

--- a/compress.hpp
+++ b/compress.hpp
@@ -33,8 +33,7 @@ class iter::impl::Compressed {
  public:
   Compressed(Compressed&&) = default;
   template <typename ContainerT, typename SelectorT>
-  class Iterator : public std::iterator<std::input_iterator_tag,
-                       iterator_traits_deref<ContainerT>> {
+  class Iterator {
    private:
     template <typename, typename>
     friend class Iterator;
@@ -57,6 +56,12 @@ class iter::impl::Compressed {
     }
 
    public:
+    using iterator_category = std::input_iterator_tag;
+    using value_type = iterator_traits_deref<ContainerT>;
+    using difference_type = std::ptrdiff_t;
+    using pointer = value_type*;
+    using reference = value_type&;
+
     Iterator(IteratorWrapper<ContainerT>&& cont_iter,
         IteratorWrapper<ContainerT>&& cont_end,
         IteratorWrapper<SelectorT>&& sel_iter,

--- a/cycle.hpp
+++ b/cycle.hpp
@@ -31,8 +31,7 @@ class iter::impl::Cycler {
  public:
   Cycler(Cycler&&) = default;
   template <typename ContainerT>
-  class Iterator : public std::iterator<std::input_iterator_tag,
-                       iterator_traits_deref<ContainerT>> {
+  class Iterator {
    private:
     template <typename>
     friend class Iterator;
@@ -41,6 +40,12 @@ class iter::impl::Cycler {
     IteratorWrapper<ContainerT> sub_end_;
 
    public:
+    using iterator_category = std::input_iterator_tag;
+    using value_type = iterator_traits_deref<ContainerT>;
+    using difference_type = std::ptrdiff_t;
+    using pointer = value_type*;
+    using reference = value_type&;
+
     Iterator(IteratorWrapper<ContainerT>&& sub_iter,
         IteratorWrapper<ContainerT>&& sub_end)
         : sub_iter_{sub_iter},

--- a/dropwhile.hpp
+++ b/dropwhile.hpp
@@ -33,8 +33,7 @@ class iter::impl::Dropper {
  public:
   Dropper(Dropper&&) = default;
   template <typename ContainerT>
-  class Iterator : public std::iterator<std::input_iterator_tag,
-                       iterator_traits_deref<ContainerT>> {
+  class Iterator {
    private:
     template <typename>
     friend class Iterator;
@@ -59,6 +58,12 @@ class iter::impl::Dropper {
     }
 
    public:
+    using iterator_category = std::input_iterator_tag;
+    using value_type = iterator_traits_deref<ContainerT>;
+    using difference_type = std::ptrdiff_t;
+    using pointer = value_type*;
+    using reference = value_type&;
+
     Iterator(IteratorWrapper<ContainerT>&& sub_iter,
         IteratorWrapper<ContainerT>&& sub_end, FilterFunc& filter_func)
         : sub_iter_{std::move(sub_iter)},

--- a/enumerate.hpp
+++ b/enumerate.hpp
@@ -68,8 +68,7 @@ class iter::impl::Enumerable {
   //  index_.  Each call to ++ increments both of these data members.
   //  Each dereference returns an IterYield.
   template <typename ContainerT>
-  class Iterator
-      : public std::iterator<std::input_iterator_tag, IterYield<ContainerT>> {
+  class Iterator {
    private:
     template <typename>
     friend class Iterator;
@@ -77,6 +76,12 @@ class iter::impl::Enumerable {
     Index index_;
 
    public:
+    using iterator_category = std::input_iterator_tag;
+    using value_type = IterYield<ContainerT>;
+    using difference_type = std::ptrdiff_t;
+    using pointer = value_type*;
+    using reference = value_type&;
+
     Iterator(IteratorWrapper<ContainerT>&& sub_iter, Index start)
         : sub_iter_{std::move(sub_iter)}, index_{start} {}
 

--- a/filter.hpp
+++ b/filter.hpp
@@ -44,8 +44,7 @@ class iter::impl::Filtered {
   Filtered(Filtered&&) = default;
 
   template <typename ContainerT>
-  class Iterator : public std::iterator<std::input_iterator_tag,
-                       iterator_traits_deref<ContainerT>> {
+  class Iterator {
    protected:
     template <typename>
     friend class Iterator;
@@ -71,6 +70,12 @@ class iter::impl::Filtered {
     }
 
    public:
+    using iterator_category = std::input_iterator_tag;
+    using value_type = iterator_traits_deref<ContainerT>;
+    using difference_type = std::ptrdiff_t;
+    using pointer = value_type*;
+    using reference = value_type&;
+
     Iterator(IteratorWrapper<ContainerT>&& sub_iter,
         IteratorWrapper<ContainerT>&& sub_end, FilterFunc& filter_func)
         : sub_iter_{std::move(sub_iter)},

--- a/groupby.hpp
+++ b/groupby.hpp
@@ -58,8 +58,7 @@ class iter::impl::GroupProducer {
 
  public:
   template <typename ContainerT>
-  class Iterator : public std::iterator<std::input_iterator_tag,
-                       KeyGroupPair<ContainerT>> {
+  class Iterator {
    private:
     template <typename>
     friend class Iterator;
@@ -70,6 +69,12 @@ class iter::impl::GroupProducer {
     std::unique_ptr<KeyGroupPair<ContainerT>> current_key_group_pair_;
 
    public:
+    using iterator_category = std::input_iterator_tag;
+    using value_type = KeyGroupPair<ContainerT>;
+    using difference_type = std::ptrdiff_t;
+    using pointer = value_type*;
+    using reference = value_type&;
+
     Iterator(IteratorWrapper<ContainerT>&& sub_iter,
         IteratorWrapper<ContainerT>&& sub_end, KeyFunc& key_func)
         : sub_iter_{std::move(sub_iter)},
@@ -208,8 +213,7 @@ class iter::impl::GroupProducer {
       other.completed = true;
     }
 
-    class GroupIterator : public std::iterator<std::input_iterator_tag,
-                              iterator_traits_deref<ContainerT>> {
+    class GroupIterator {
      private:
       std::remove_reference_t<key_func_ret<ContainerT>>* key_;
       Group* group_p_;
@@ -220,6 +224,12 @@ class iter::impl::GroupProducer {
       }
 
      public:
+      using iterator_category = std::input_iterator_tag;
+      using value_type = iterator_traits_deref<ContainerT>;
+      using difference_type = std::ptrdiff_t;
+      using pointer = value_type*;
+      using reference = value_type&;
+
       // TODO template this? idk if it's relevant here
       GroupIterator(Group* group_p, key_func_ret<ContainerT>& key)
           : key_{&key}, group_p_{group_p} {}

--- a/internal/iteratoriterator.hpp
+++ b/internal/iteratoriterator.hpp
@@ -23,10 +23,7 @@ namespace iter {
         : std::true_type {};
 
     template <typename TopIter>
-    class IteratorIterator
-        : public std::iterator<std::random_access_iterator_tag,
-              typename std::remove_reference<decltype(
-                  **std::declval<TopIter>())>::type> {
+    class IteratorIterator {
       template <typename> friend class IteratorIterator;
       using Diff = std::ptrdiff_t;
       static_assert(
@@ -39,6 +36,11 @@ namespace iter {
       TopIter sub_iter;
 
      public:
+      using iterator_category = std::random_access_iterator_tag;
+      using value_type = std::remove_reference_t<decltype(**std::declval<TopIter>())>;
+      using difference_type = std::ptrdiff_t;
+      using pointer = value_type*;
+      using reference = value_type&;
       IteratorIterator() = default;
       IteratorIterator(const TopIter& it) : sub_iter{it} {}
 

--- a/permutations.hpp
+++ b/permutations.hpp
@@ -38,8 +38,7 @@ class iter::impl::Permuter {
   Permuter(Permuter&&) = default;
 
   template <typename ContainerT>
-  class Iterator
-      : public std::iterator<std::input_iterator_tag, Permutable<ContainerT>> {
+  class Iterator {
    private:
     template <typename>
     friend class Iterator;
@@ -53,6 +52,12 @@ class iter::impl::Permuter {
     int steps_{};
 
    public:
+    using iterator_category = std::input_iterator_tag;
+    using value_type = Permutable<ContainerT>;
+    using difference_type = std::ptrdiff_t;
+    using pointer = value_type*;
+    using reference = value_type&;
+
     Iterator(IteratorWrapper<ContainerT>&& sub_iter,
         IteratorWrapper<ContainerT>&& sub_end)
         : steps_{sub_iter != sub_end ? 0 : COMPLETE} {

--- a/powerset.hpp
+++ b/powerset.hpp
@@ -37,8 +37,7 @@ class iter::impl::Powersetter {
   Powersetter(Powersetter&&) = default;
 
   template <typename ContainerT>
-  class Iterator : public std::iterator<std::input_iterator_tag,
-                       CombinatorType<ContainerT>> {
+  class Iterator {
    private:
 #if 0
     template <typename> friend class Iterator;
@@ -50,6 +49,12 @@ class iter::impl::Powersetter {
     iterator_type<CombinatorType<ContainerT>> comb_end_;
 
    public:
+    using iterator_category = std::input_iterator_tag;
+    using value_type = CombinatorType<ContainerT>;
+    using difference_type = std::ptrdiff_t;
+    using pointer = value_type*;
+    using reference = value_type&;
+
     Iterator(ContainerT& container, std::size_t sz)
         : container_p_{&container},
           set_size_{sz},

--- a/product.hpp
+++ b/product.hpp
@@ -50,8 +50,7 @@ class iter::impl::Productor<Container, RestContainers...> {
 
  private:
   template <typename ContainerT, typename RestIter>
-  class IteratorTempl : public std::iterator<std::input_iterator_tag,
-                            ProdIterDeref<ContainerT>> {
+  class IteratorTempl {
    private:
     template <typename, typename>
     friend class IteratorTempl;
@@ -62,6 +61,12 @@ class iter::impl::Productor<Container, RestContainers...> {
     RestIter rest_end_;
 
    public:
+    using iterator_category = std::input_iterator_tag;
+    using value_type = ProdIterDeref<ContainerT>;
+    using difference_type = std::ptrdiff_t;
+    using pointer = value_type*;
+    using reference = value_type&;
+
     constexpr static const bool is_base_iter = false;
     IteratorTempl(IteratorWrapper<ContainerT>&& sub_iter, RestIter&& rest_iter,
         RestIter&& rest_end)
@@ -144,8 +149,14 @@ template <>
 class iter::impl::Productor<> {
  public:
   Productor(Productor&&) = default;
-  class Iterator : public std::iterator<std::input_iterator_tag, std::tuple<>> {
+  class Iterator {
    public:
+    using iterator_category = std::input_iterator_tag;
+    using value_type = std::tuple<>;
+    using difference_type = std::ptrdiff_t;
+    using pointer = value_type*;
+    using reference = value_type&;
+
     constexpr static const bool is_base_iter = true;
 
     void reset() {}

--- a/range.hpp
+++ b/range.hpp
@@ -132,8 +132,7 @@ class iter::impl::Range {
   // of the rules, but std::vector<bool>::iterator::reference isn't
   // a reference type either, this isn't any worse
 
-  class Iterator : public std::iterator<std::forward_iterator_tag, T,
-                       std::ptrdiff_t, T*, T> {
+  class Iterator {
    private:
     iter::detail::RangeIterData<T> data;
     bool is_end;
@@ -166,6 +165,12 @@ class iter::impl::Range {
     }
 
    public:
+    using iterator_category = std::forward_iterator_tag;
+    using value_type = T;
+    using difference_type = std::ptrdiff_t;
+    using pointer = value_type*;
+    using reference = value_type&;
+
     constexpr Iterator() noexcept = default;
 
     constexpr Iterator(T in_value, T in_step, bool in_is_end) noexcept

--- a/range.hpp
+++ b/range.hpp
@@ -169,7 +169,7 @@ class iter::impl::Range {
     using value_type = T;
     using difference_type = std::ptrdiff_t;
     using pointer = value_type*;
-    using reference = value_type&;
+    using reference = value_type;
 
     constexpr Iterator() noexcept = default;
 

--- a/repeat.hpp
+++ b/repeat.hpp
@@ -34,12 +34,18 @@ class iter::impl::RepeaterWithCount {
  public:
   RepeaterWithCount(RepeaterWithCount&&) = default;
 
-  class Iterator : public std::iterator<std::input_iterator_tag, const TPlain> {
+  class Iterator {
    private:
     const TPlain* elem_;
     int count_;
 
    public:
+    using iterator_category = std::input_iterator_tag;
+    using value_type = const TPlain;
+    using difference_type = std::ptrdiff_t;
+    using pointer = value_type*;
+    using reference = value_type&;
+
     constexpr Iterator(const TPlain* e, int c) : elem_{e}, count_{c} {}
 
     Iterator& operator++() {
@@ -108,11 +114,17 @@ class iter::impl::Repeater {
  public:
   Repeater(Repeater&&) = default;
 
-  class Iterator : public std::iterator<std::input_iterator_tag, const TPlain> {
+  class Iterator {
    private:
     const TPlain* elem_;
 
    public:
+    using iterator_category = std::input_iterator_tag;
+    using value_type = const TPlain;
+    using difference_type = std::ptrdiff_t;
+    using pointer = value_type*;
+    using reference = value_type&;
+
     constexpr Iterator(const TPlain* e) : elem_{e} {}
 
     constexpr const Iterator& operator++() const {

--- a/reversed.hpp
+++ b/reversed.hpp
@@ -71,14 +71,19 @@ class iter::impl::Reverser {
  public:
   Reverser(Reverser&&) = default;
   template <typename ContainerT>
-  class Iterator : public std::iterator<std::input_iterator_tag,
-                       reverse_iterator_traits_deref<ContainerT>> {
+  class Iterator {
    private:
     template <typename>
     friend class Iterator;
     ReverseIteratorWrapper<ContainerT> sub_iter_;
 
    public:
+    using iterator_category = std::input_iterator_tag;
+    using value_type = reverse_iterator_traits_deref<ContainerT>;
+    using difference_type = std::ptrdiff_t;
+    using pointer = value_type*;
+    using reference = value_type&;
+
     Iterator(ReverseIteratorWrapper<ContainerT>&& sub_iter)
         : sub_iter_{std::move(sub_iter)} {}
 

--- a/slice.hpp
+++ b/slice.hpp
@@ -36,8 +36,7 @@ class iter::impl::Sliced {
  public:
   Sliced(Sliced&&) = default;
   template <typename ContainerT>
-  class Iterator : public std::iterator<std::input_iterator_tag,
-                       iterator_traits_deref<ContainerT>> {
+  class Iterator {
    private:
     template <typename>
     friend class Iterator;
@@ -48,6 +47,12 @@ class iter::impl::Sliced {
     DifferenceType step_;
 
    public:
+    using iterator_category = std::input_iterator_tag;
+    using value_type = iterator_traits_deref<ContainerT>;
+    using difference_type = std::ptrdiff_t;
+    using pointer = value_type*;
+    using reference = value_type&;
+
     Iterator(IteratorWrapper<ContainerT>&& sub_iter,
         IteratorWrapper<ContainerT>&& sub_end, DifferenceType start,
         DifferenceType stop, DifferenceType step)

--- a/sliding_window.hpp
+++ b/sliding_window.hpp
@@ -37,8 +37,7 @@ class iter::impl::WindowSlider {
  public:
   WindowSlider(WindowSlider&&) = default;
   template <typename ContainerT>
-  class Iterator
-      : public std::iterator<std::input_iterator_tag, DerefVec<ContainerT>> {
+  class Iterator {
    private:
     template <typename>
     friend class Iterator;
@@ -46,6 +45,12 @@ class iter::impl::WindowSlider {
     DerefVec<ContainerT> window_;
 
    public:
+    using iterator_category = std::input_iterator_tag;
+    using value_type = DerefVec<ContainerT>;
+    using difference_type = std::ptrdiff_t;
+    using pointer = value_type*;
+    using reference = value_type&;
+
     Iterator(IteratorWrapper<ContainerT>&& sub_iter,
         IteratorWrapper<ContainerT>&& sub_end, std::size_t window_sz)
         : sub_iter_(std::move(sub_iter)) {

--- a/starmap.hpp
+++ b/starmap.hpp
@@ -44,8 +44,7 @@ class iter::impl::StarMapper {
 
  public:
   template <typename ContainerT>
-  class Iterator
-      : public std::iterator<std::input_iterator_tag, StarIterDeref> {
+  class Iterator {
    private:
     template <typename>
     friend class Iterator;
@@ -53,6 +52,12 @@ class iter::impl::StarMapper {
     IteratorWrapper<ContainerT> sub_iter_;
 
    public:
+    using iterator_category = std::input_iterator_tag;
+    using value_type = StarIterDeref;
+    using difference_type = std::ptrdiff_t;
+    using pointer = value_type*;
+    using reference = value_type&;
+
     Iterator(Func& f, IteratorWrapper<ContainerT>&& sub_iter)
         : func_(&f), sub_iter_(std::move(sub_iter)) {}
 
@@ -142,8 +147,7 @@ class iter::impl::TupleStarMapper {
 
  public:
   template <typename TupTypeT>
-  class Iterator : public std::iterator<std::input_iterator_tag,
-                       typename IteratorData<TupTypeT>::TraitsValue> {
+  class Iterator {
    private:
     template <typename>
     friend class Iterator;
@@ -152,6 +156,12 @@ class iter::impl::TupleStarMapper {
     std::size_t index_;
 
    public:
+    using iterator_category = std::input_iterator_tag;
+    using value_type = typename IteratorData<TupTypeT>::TraitsValue;
+    using difference_type = std::ptrdiff_t;
+    using pointer = value_type*;
+    using reference = value_type&;
+
     Iterator(Func& f, TupTypeT& t, std::size_t i)
         : func_{&f}, tup_{&t}, index_{i} {}
 

--- a/takewhile.hpp
+++ b/takewhile.hpp
@@ -34,8 +34,7 @@ class iter::impl::Taker {
   Taker(Taker&&) = default;
 
   template <typename ContainerT>
-  class Iterator : public std::iterator<std::input_iterator_tag,
-                       iterator_traits_deref<ContainerT>> {
+  class Iterator {
    private:
     template <typename>
     friend class Iterator;
@@ -59,6 +58,12 @@ class iter::impl::Taker {
     }
 
    public:
+    using iterator_category = std::input_iterator_tag;
+    using value_type = iterator_traits_deref<ContainerT>;
+    using difference_type = std::ptrdiff_t;
+    using pointer = value_type*;
+    using reference = value_type&;
+
     Iterator(IteratorWrapper<ContainerT>&& sub_iter,
         IteratorWrapper<ContainerT>&& sub_end, FilterFunc& filter_func)
         : sub_iter_{std::move(sub_iter)},

--- a/zip.hpp
+++ b/zip.hpp
@@ -40,14 +40,19 @@ class iter::impl::Zipped {
   // deref they'd need to be known in the function declarations below.
   template <typename TupleTypeT, template <typename> class IteratorTuple,
       template <typename> class TupleDeref>
-  class Iterator
-      : public std::iterator<std::input_iterator_tag, TupleDeref<TupleTypeT>> {
+  class Iterator {
    private:
     template <typename, template <typename> class, template <typename> class>
     friend class Iterator;
     IteratorTuple<TupleTypeT> iters_;
 
    public:
+    using iterator_category = std::input_iterator_tag;
+    using value_type = TupleDeref<TupleTypeT>;
+    using difference_type = std::ptrdiff_t;
+    using pointer = value_type*;
+    using reference = value_type&;
+
     Iterator(IteratorTuple<TupleTypeT>&& iters) : iters_(std::move(iters)) {}
 
     Iterator& operator++() {

--- a/zip_longest.hpp
+++ b/zip_longest.hpp
@@ -49,8 +49,7 @@ class iter::impl::ZippedLongest {
   ZippedLongest(ZippedLongest&&) = default;
   template <typename TupleTypeT, template <typename> class IterTuple,
       template <std::size_t, typename> class OptTempl>
-  class Iterator : public std::iterator<std::input_iterator_tag,
-                       ZipIterDeref<TupleTypeT, OptTempl>> {
+  class Iterator {
    private:
     template <typename, template <typename> class,
         template <std::size_t, typename> class>
@@ -59,6 +58,12 @@ class iter::impl::ZippedLongest {
     IterTuple<TupleTypeT> ends_;
 
    public:
+    using iterator_category = std::input_iterator_tag;
+    using value_type = ZipIterDeref<TupleTypeT, OptTempl>;
+    using difference_type = std::ptrdiff_t;
+    using pointer = value_type*;
+    using reference = value_type&;
+
     Iterator(IterTuple<TupleTypeT>&& iters, IterTuple<TupleTypeT>&& ends)
         : iters_(std::move(iters)), ends_(std::move(ends)) {}
 


### PR DESCRIPTION
In response to #31.

I tried running clang-format with your .clang-format file but it also made changes on lines I hadn't touched,
so I undid those changes.

You can `grep -rs 'std::iterator<' .` to double check that all inheritances from `std::iterator` are gone.