### PR TITLE
Modify get_begin() get_end() to use either member functions or ADL

### DIFF
--- a/test/test_iterbase.cpp
+++ b/test/test_iterbase.cpp
@@ -94,3 +94,31 @@ TEST_CASE("get_begin returns correct type", "[iterbase]") {
   std::vector<int> v;
   REQUIRE((std::is_same<decltype(it::get_begin(v)), decltype(v.begin())>{}));
 }
+
+namespace NS1 {
+
+  struct Dummy {
+    auto begin() {
+      return 0;
+    }
+    auto end() {
+      return 0;
+    }
+  };
+
+  template <typename T>
+  auto begin(T& t) {
+    return t.begin();
+  }
+
+  template <typename T>
+  auto end(T& t) {
+    return t.end();
+  }
+
+}  // namespace NS1
+
+TEST_CASE("Detects is_iterable with ADL conflicts", "[iterbase]") {
+  REQUIRE(iter::impl::is_iterable<NS1::Dummy>);
+  REQUIRE(iter::impl::is_iterable<std::vector<NS1::Dummy>>);
+}


### PR DESCRIPTION
The current implementation of `get_begin()` and `get_end()` relies exclusively on ADL. It causes compilation errors when using collections for which ADL fails which is the case for EASTL containers. Since EASTL defines `begin()` and `end()` the same way the std does:
```
namespace eastl {
    template <typename Container>
    auto begin(Container& container) -> decltype(container.begin());
}
```
then the following cause an ambiguous call:
```
using std::begin;
eastl::vector<int> v;
begin(v); // std::begin() or eastl::begin()?
```
This pull request mimic how range-v3 does by defining 3 variants of the `get_begin()`:
- the variant for C arrays
- the variant using ADL (but not pulling `std::begin`)
- the variant using directly member `begin()` solving the case for EASTL containers and other ADL issues