### PR TITLE
fix chain.from_iterable() when subiterables are empty

### DIFF
--- a/chain.hpp
+++ b/chain.hpp
@@ -204,7 +204,14 @@ class iter::impl::ChainedFromIterable {
     std::optional<SubIter> sub_iter_p_;
     std::optional<SubIter> sub_end_p_;
 
-    void next_sub_iterable() {
+    void advance_while_empty_sub_iterable() {
+      while (top_level_iter_ != top_level_end_ && sub_iter_p_ == sub_end_p_) {
+        ++top_level_iter_;
+        update_sub_iterable();
+      }
+    }
+
+    void update_sub_iterable() {
       if (top_level_iter_ != top_level_end_) {
         sub_iterable_.reset(*top_level_iter_);
         sub_iter_p_ =
@@ -214,6 +221,11 @@ class iter::impl::ChainedFromIterable {
         sub_iter_p_.reset();
         sub_end_p_.reset();
       }
+    }
+
+    void next_sub_iterable() {
+      update_sub_iterable();
+      advance_while_empty_sub_iterable();
     }
 
    public:

--- a/internal/iterator_wrapper.hpp
+++ b/internal/iterator_wrapper.hpp
@@ -94,6 +94,10 @@ class iter::impl::IteratorWrapperImpl {
     } not_equal;
     return std::visit(not_equal, sub_iter_or_end_, other.sub_iter_or_end_);
   }
+
+  bool operator==(const IteratorWrapperImpl& other) const {
+    return !(*this != other);
+  }
 };
 
 #endif

--- a/test/test_chain.cpp
+++ b/test/test_chain.cpp
@@ -233,6 +233,16 @@ TEST_CASE("chain.fromm_iterable: Works with different begin and end types",
   REQUIRE(v == vc);
 }
 
+TEST_CASE("chain.from_iterable: Works with empty subiterable",
+    "[chain.from_iterable]") {
+  std::vector<std::vector<int>> ivv{
+      {}, {2, 4, 6}, {}, {8, 10, 12}, {14, 16, 18}, {}};
+  auto ch = chain.from_iterable(ivv);
+  const std::vector<int> v(std::begin(ch), std::end(ch));
+  const std::vector<int> vi = {2, 4, 6, 8, 10, 12, 14, 16, 18};
+  REQUIRE(v == vi);
+}
+
 TEST_CASE(
     "chain.from_iterable: iterators cant be copy constructed "
     "and assigned",


### PR DESCRIPTION
`chain.from_iterable()` cause out of bounds access if one of the sub iterable is empty like:
```
std::vector<std::vector<int>> values {
    {},
    {2, 4, 6},
    {},
    {8, 10, 12},
    {14, 16, 18},
    {}
};
```
