### PR TITLE
New proposed tool: batched

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -2,6 +2,7 @@ cc_library(
     name = "cppitertools",
     hdrs = [
         "accumulate.hpp",
+        "batched.hpp",
         "chain.hpp",
         "chunked.hpp",
         "combinations.hpp",

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Status | Compilers
 [slice](#slice)<br />
 [sliding\_window](#sliding_window)<br />
 [chunked](#chunked)<br />
+[batched](#batched)<br />
 
 ##### Combinatoric fuctions
 [product](#product)<br />
@@ -168,6 +169,7 @@ would expect them to behave:
 - accumulate
 - chain.from\_iterable
 - chunked
+- batched
 - combinations
 - combinations\_with\_replacement
 - cycle
@@ -753,7 +755,7 @@ for (auto&& sec : sliding_window(v,4)) {
 chunked
 ------
 
-chunked will yield subsequent chunkes of an iterable in blocks of a specified
+chunked will yield subsequent chunks of an iterable in blocks of a specified
 size. The final chunk may be shorter than the rest if the chunk size given
 does not evenly divide the length of the iterable.
 
@@ -773,6 +775,32 @@ The above prints:
 1 2 3 4
 5 6 7 8
 9
+```
+batched
+-------
+
+batched will yield a given number N of batches containing subsequent elements from an iterable,
+assuming the iterable contains at least N elements.
+The size of each batch is immaterial, but the implementation guarantees that no two batches will
+differ in size by more than 1. 
+
+Example usage:
+```c++
+vector<int> v {1,2,3,4,5,6,7,8,9};
+for (auto&& sec : batched(v,4)) {
+    for (auto&& i : sec) {
+        cout << i << ' ';
+    }
+    cout << '\n';
+}
+```
+
+The above prints:
+```
+1 2 3
+4 5
+6 7
+8 9
 ```
 
 product

--- a/batched.hpp
+++ b/batched.hpp
@@ -1,0 +1,141 @@
+#ifndef ITER_BATCHED_HPP_
+#define ITER_BATCHED_HPP_
+
+#include "internal/iterator_wrapper.hpp"
+#include "internal/iteratoriterator.hpp"
+#include "internal/iterbase.hpp"
+
+#include <algorithm>
+#include <functional>
+#include <iterator>
+#include <memory>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+namespace iter {
+  namespace impl {
+    template <typename Container>
+    class Batcher;
+
+    using BatchedFn = IterToolFnBindSizeTSecond<Batcher>;
+  }
+  constexpr impl::BatchedFn batched{};
+}
+
+template <typename Container>
+class iter::impl::Batcher {
+ private:
+  Container container_;
+  std::size_t num_batches_;
+
+  Batcher(Container&& container, std::size_t const num_batches)
+      : container_(std::forward<Container>(container)), num_batches_{num_batches} {}
+
+  friend BatchedFn;
+
+  template <typename T>
+  using IndexVector = std::vector<IteratorWrapper<T>>;
+  template <typename T>
+  using DerefVec = IterIterWrapper<IndexVector<T>>;
+
+ public:
+  Batcher(Batcher&&) = default;
+  template <typename ContainerT>
+  class Iterator {
+   private:
+    template <typename>
+    friend class Iterator;
+    std::shared_ptr<DerefVec<ContainerT>> batch_ =
+        std::make_shared<DerefVec<ContainerT>>();
+    IteratorWrapper<ContainerT> sub_iter_;
+    IteratorWrapper<ContainerT> sub_end_;
+    std::size_t num_batches_;
+    std::size_t size_;
+    std::size_t count_;
+
+    bool done() const {
+      return batch_->empty();
+    }
+
+    void refill_batch() {
+      batch_->get().clear();
+      if (count_ < num_batches_) {
+        std::size_t const batch_size(size_ / num_batches_ + std::min<std::size_t>(1, (size_ % num_batches_) / (count_ + 1)));
+        batch_->get().reserve(batch_size);
+        for (std::size_t i = 0; i < batch_size; ++i) {
+          batch_->get().push_back(sub_iter_);
+          ++sub_iter_;
+        }
+        ++count_;
+      }
+    }
+
+   public:
+    using iterator_category = std::input_iterator_tag;
+    using value_type = DerefVec<ContainerT>;
+    using difference_type = std::ptrdiff_t;
+    using pointer = value_type*;
+    using reference = value_type&;
+
+    Iterator(IteratorWrapper<ContainerT>&& sub_iter,
+        IteratorWrapper<ContainerT>&& sub_end, std::size_t num_batches)
+        : sub_iter_{std::move(sub_iter)},
+          sub_end_{std::move(sub_end)},
+          num_batches_{num_batches},
+          size_{static_cast<std::size_t>(std::distance(sub_iter_, sub_end_))},
+          count_{0} {
+      refill_batch();
+    }
+
+    Iterator& operator++() {
+      refill_batch();
+      return *this;
+    }
+
+    Iterator operator++(int) {
+      auto ret = *this;
+      ++*this;
+      return ret;
+    }
+
+    template <typename T>
+    bool operator!=(const Iterator<T>& other) const {
+      return !(*this == other);
+    }
+
+    template <typename T>
+    bool operator==(const Iterator<T>& other) const {
+      return done() == other.done()
+             && (done() || !(sub_iter_ != other.sub_iter_));
+    }
+
+    DerefVec<ContainerT>& operator*() {
+      return *batch_;
+    }
+
+    DerefVec<ContainerT>* operator->() {
+      return batch_.get();
+    }
+  };
+
+  Iterator<Container> begin() {
+    return {get_begin(container_), get_end(container_), num_batches_};
+  }
+
+  Iterator<Container> end() {
+    return {get_end(container_), get_end(container_), num_batches_};
+  }
+
+  Iterator<AsConst<Container>> begin() const {
+    return {get_begin(std::as_const(container_)),
+        get_end(std::as_const(container_)), num_batches_};
+  }
+
+  Iterator<AsConst<Container>> end() const {
+    return {get_end(std::as_const(container_)),
+        get_end(std::as_const(container_)), num_batches_};
+  }
+};
+
+#endif

--- a/examples/SConstruct
+++ b/examples/SConstruct
@@ -15,6 +15,7 @@ env['ENV']['TERM'] = os.environ['TERM']
 progs = Split(
     '''
     accumulate
+    batched
     chain
     chunked
     combinatoric

--- a/examples/batched_examples.cpp
+++ b/examples/batched_examples.cpp
@@ -1,0 +1,23 @@
+#include <batched.hpp>
+
+#include <iostream>
+#include <vector>
+
+int main() {
+    std::vector<int> v {1,2,3,4,5,6,7,8,9}; 
+    std::cout << "num batches: 5\n";
+    for (auto&& sec : iter::batched(v, 5)) {
+        for (auto&& i : sec) {
+            std::cout << i << " ";
+        }
+        std::cout << '\n';
+    }
+
+    std::cout << "num batches: 4\n";
+    for (auto&& sec : iter::batched(v,4)) {
+        for (auto&& i : sec) {
+            std::cout << i << " ";
+        }
+        std::cout << '\n';
+    }
+}

--- a/examples/batched_examples.cpp
+++ b/examples/batched_examples.cpp
@@ -14,7 +14,7 @@ int main() {
     }
 
     std::cout << "num batches: 4\n";
-    for (auto&& sec : iter::batched(v,4)) {
+    for (auto&& sec : iter::batched(v, 4)) {
         for (auto&& i : sec) {
             std::cout << i << " ";
         }

--- a/examples/batched_examples.cpp
+++ b/examples/batched_examples.cpp
@@ -20,4 +20,12 @@ int main() {
         }
         std::cout << '\n';
     }
+
+    std::cout << "num batches: 6\n";
+    for (auto&& sec : iter::batched(v, 6)) {
+        for (auto&& i : sec) {
+            std::cout << i << " ";
+        }
+        std::cout << '\n';
+    }
 }

--- a/itertools.hpp
+++ b/itertools.hpp
@@ -2,6 +2,7 @@
 #define ITERTOOLS_ALL_HPP_
 
 #include "accumulate.hpp"
+#include "batched.hpp"
 #include "chain.hpp"
 #include "chunked.hpp"
 #include "combinations.hpp"

--- a/test/BUILD
+++ b/test/BUILD
@@ -2,6 +2,7 @@ load(":make_tests.bzl", "itertools_tests")
 
 progs = [
     "accumulate",
+    "batched",
     "chain",
     "chunked",
     "combinations",

--- a/test/SConstruct
+++ b/test/SConstruct
@@ -23,6 +23,7 @@ if env['CXX'].startswith('clang++'):
 progs = Split(
     '''
     accumulate
+    batched
     chain
     chunked
     combinations

--- a/test/test_batched.cpp
+++ b/test/test_batched.cpp
@@ -52,7 +52,7 @@ TEST_CASE("batched: const iterators can be compared to non-const iterators",
   (void)(std::begin(c) == std::end(cc));
 }
 
-TEST_CASE("batched: len(iterable) % groupsize != 0", "[batched]") {
+TEST_CASE("batched: len(iterable) % num_batches != 0", "[batched]") {
   Vec ns = {1, 2, 3, 4, 5, 6, 7};
   ResVec results;
   for (auto&& g : batched(ns, 3)) {
@@ -60,6 +60,18 @@ TEST_CASE("batched: len(iterable) % groupsize != 0", "[batched]") {
   }
 
   ResVec rc = {{1, 2, 3}, {4, 5}, {6, 7}};
+
+  REQUIRE(results == rc);
+}
+
+TEST_CASE("batched: num_batches > len(iterable)", "[batched]") {
+  Vec ns = {1, 2, 3, 4, 5, 6, 7};
+  ResVec results;
+  for (auto&& g : batched(ns, 9)) {
+    results.emplace_back(std::begin(g), std::end(g));
+  }
+
+  ResVec rc = {{1}, {2}, {3}, {4}, {5}, {6}, {7}};
 
   REQUIRE(results == rc);
 }

--- a/test/test_batched.cpp
+++ b/test/test_batched.cpp
@@ -1,0 +1,101 @@
+#include <batched.hpp>
+
+#include <array>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "catch.hpp"
+#include "helpers.hpp"
+
+using iter::batched;
+using Vec = std::vector<int>;
+using ResVec = std::vector<Vec>;
+
+TEST_CASE("batched: basic test", "[batched]") {
+  Vec ns = {1, 2, 3, 4, 5, 6};
+  ResVec results;
+  SECTION("Normal call") {
+    for (auto&& g : batched(ns, 2)) {
+      results.emplace_back(std::begin(g), std::end(g));
+    }
+  }
+  SECTION("Pipe") {
+    for (auto&& g : ns | batched(2)) {
+      results.emplace_back(std::begin(g), std::end(g));
+    }
+  }
+
+  ResVec rc = {{1, 2, 3}, {4 ,5, 6}};
+
+  REQUIRE(results == rc);
+}
+
+TEST_CASE("batched: const batched", "[batched][const]") {
+  Vec ns = {1, 2, 3, 4, 5, 6};
+  ResVec results;
+  SECTION("Normal call") {
+    const auto& ch = batched(ns, 2);
+    for (auto&& g : ch) {
+      results.emplace_back(std::begin(g), std::end(g));
+    }
+  }
+  ResVec rc = {{1, 2, 3}, {4, 5, 6}};
+
+  REQUIRE(results == rc);
+}
+
+TEST_CASE("batched: const iterators can be compared to non-const iterators",
+    "[batched][const]") {
+  auto c = batched(Vec{}, 1);
+  const auto& cc = c;
+  (void)(std::begin(c) == std::end(cc));
+}
+
+TEST_CASE("batched: len(iterable) % groupsize != 0", "[batched]") {
+  Vec ns = {1, 2, 3, 4, 5, 6, 7};
+  ResVec results;
+  for (auto&& g : batched(ns, 3)) {
+    results.emplace_back(std::begin(g), std::end(g));
+  }
+
+  ResVec rc = {{1, 2, 3}, {4, 5}, {6, 7}};
+
+  REQUIRE(results == rc);
+}
+
+TEST_CASE("batched: iterators can be compared", "[batched]") {
+  Vec ns = {1, 2, 3, 4, 5, 6, 7};
+  auto g = batched(ns, 3);
+  auto it = std::begin(g);
+  REQUIRE(it == std::begin(g));
+  REQUIRE_FALSE(it != std::begin(g));
+  ++it;
+  REQUIRE(it != std::begin(g));
+  REQUIRE_FALSE(it == std::begin(g));
+}
+
+TEST_CASE("batched: size 0 is empty", "[batched]") {
+  Vec ns{1, 2, 3};
+  auto g = batched(ns, 0);
+  REQUIRE(std::begin(g) == std::end(g));
+}
+
+TEST_CASE("batched: empty iterable gives empty batched", "[batched]") {
+  Vec ns{};
+  auto g = batched(ns, 1);
+  REQUIRE(std::begin(g) == std::end(g));
+}
+
+TEST_CASE("batched: iterator meets requirements", "[batched]") {
+  std::string s{};
+  auto c = batched(s, 1);
+  REQUIRE(itertest::IsIterator<decltype(std::begin(c))>::value);
+}
+
+template <typename T>
+using ImpT = decltype(batched(std::declval<T>(), 1));
+TEST_CASE("batched: has correct ctor and assign ops", "[batched]") {
+  REQUIRE(itertest::IsMoveConstructibleOnly<ImpT<std::string&>>::value);
+  REQUIRE(itertest::IsMoveConstructibleOnly<ImpT<std::string>>::value);
+}

--- a/test/test_batched.cpp
+++ b/test/test_batched.cpp
@@ -81,6 +81,16 @@ TEST_CASE("batched: size 0 is empty", "[batched]") {
   REQUIRE(std::begin(g) == std::end(g));
 }
 
+TEST_CASE("batched: Works with different begin and end types", "[batched]") {
+  CharRange cr{'f'};
+  std::vector<std::vector<char>> results;
+  for (auto&& g : batched(cr, 3)) {
+    results.emplace_back(std::begin(g), std::end(g));
+  }
+  std::vector<std::vector<char>> rc = {{'a', 'b'}, {'c', 'd'}, {'e'}};
+  REQUIRE(results == rc);
+}
+
 TEST_CASE("batched: empty iterable gives empty batched", "[batched]") {
   Vec ns{};
   auto g = batched(ns, 1);

--- a/test/test_batched.cpp
+++ b/test/test_batched.cpp
@@ -31,6 +31,18 @@ TEST_CASE("batched: basic test", "[batched]") {
   REQUIRE(results == rc);
 }
 
+TEST_CASE("batched: uneven batch sizes", "[batched]") {
+  Vec ns = {1, 2, 3, 4, 5, 6, 7, 8, 9};
+  ResVec results;
+  for (auto&& g : batched(ns, 6)) {
+    results.emplace_back(std::begin(g), std::end(g));
+  }
+
+  ResVec rc = {{1, 2}, {3, 4}, {5, 6}, {7}, {8}, {9}};
+
+  REQUIRE(results == rc);
+}
+
 TEST_CASE("batched: const batched", "[batched][const]") {
   Vec ns = {1, 2, 3, 4, 5, 6};
   ResVec results;


### PR DESCRIPTION
First off, great library! It's been very useful to me on several occasions, and it's written in high-quality C++.
I recently needed a functionality similar to `chunked`, but where the number of chunks returned is specified, not the size of each chunk. I developed a solution that I called `batched`, and thought you'd find it a useful addition. As explained in the README, here's some typical use:
```c++
vector<int> v {1,2,3,4,5,6,7,8,9};
for (auto&& sec : batched(v,4)) {
    for (auto&& i : sec) {
        cout << i << ' ';
    }
    cout << '\n';
}
```
The above returns 4 batches, whose sizes are not specified, but are such that no two batches differ in size by more than one:
```
1 2 3
4 5
6 7
8 9
```
The implementation is quite similar to `chunked`, and is pretty straightforward. The only extra complication is the class template `distance_helper` (and its specialization), which is necessary to find the container size (needed by the algorithm) in the case of different begin and end iterator types.

Let me know if any questions or suggestions. BTW, I'm not married to the name `batched`, so please feel free to suggest a better alternative if you see fit. Thanks!