### PR TITLE
Fix CMakeLists.txt install paths

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,22 +1,34 @@
 cmake_minimum_required(VERSION 3.12)
 project(cppitertools VERSION 2.0)
-set(CMAKE_CXX_STANDARD 17)
 
+if(NOT DEFINED ENV{cppitertools_INSTALL_CMAKE_DIR})
+  message(WARNING [[
+The default value of cppitertools_INSTALL_CMAKE_DIR changed recently, from
+  "share/cppitertools/cmake"
+to
+  "share"
+in order to behave better with existing CMake practice.
+
+In order to get the previous behavior, pass
+  -Dcppitertools_INSTALL_CMAKE_DIR=share/cppitertools/cmake
+to the CMake invocation; in order to get the new behavior without the warning,
+pass
+  -Dcppitertools_INSTALL_CMAKE_DIR=share
+explicitly.
+]])
+endif()
 
 # installation directories
 set(cppitertools_INSTALL_INCLUDE_DIR "include" CACHE STRING "The installation include directory")
-set(cppitertools_INSTALL_CMAKE_DIR "share/cppitertools/cmake" CACHE STRING "The installation cmake directory")
-
+set(cppitertools_INSTALL_CMAKE_DIR "share" CACHE STRING "The installation cmake directory")
 
 # define a header-only library
 add_library(cppitertools INTERFACE)
 add_library(cppitertools::cppitertools ALIAS cppitertools)
 
 target_include_directories(cppitertools INTERFACE
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-        $<INSTALL_INTERFACE:${cppitertools_INSTALL_CMAKE_DIR}/cppitertools>
-        )
-
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+  $<INSTALL_INTERFACE:${cppitertools_INSTALL_INCLUDE_DIR}/cppitertools>)
 
 # require C++17
 target_compile_features(cppitertools INTERFACE cxx_std_17)
@@ -29,13 +41,19 @@ include(CMakePackageConfigHelpers)
 write_basic_package_version_file(cppitertools-config-version.cmake COMPATIBILITY SameMajorVersion)
 
 # install and export target
-install(TARGETS cppitertools EXPORT cppitertools-targets)
+install(
+  TARGETS cppitertools
+  EXPORT cppitertools-targets)
 
-install(EXPORT cppitertools-targets
-        FILE cppitertools-config.cmake
-        NAMESPACE cppitertools::
-        DESTINATION ${cppitertools_INSTALL_CMAKE_DIR}/cppitertools
-        )
+install(
+  DIRECTORY .
+  DESTINATION ${cppitertools_INSTALL_INCLUDE_DIR}/cppitertools)
 
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/cppitertools-config-version.cmake DESTINATION ${cppitertools_INSTALL_CMAKE_DIR})
-install(DIRECTORY . DESTINATION ${cppitertools_INSTALL_INCLUDE_DIR}/cppitertools)
+install(
+  EXPORT cppitertools-targets
+  FILE cppitertools-config.cmake
+  NAMESPACE cppitertools::
+  DESTINATION ${cppitertools_INSTALL_CMAKE_DIR}/cppitertools)
+install(
+  FILES ${CMAKE_CURRENT_BINARY_DIR}/cppitertools-config-version.cmake
+  DESTINATION ${cppitertools_INSTALL_CMAKE_DIR}/cppitertools)


### PR DESCRIPTION
The old code defaulted the cmake config install paths to
  share/cppitertools/cmake/cppitertools
whereas CMake expects the config install directory to be one of
(simplifying):
  share/cmake/cppitertools
  share/cppitertools
  share/cppitertools/cmake

Unfortunately, the existing code chose to put `cppitertools` at the end
of the install path unconditionally, and so we're left with either
`share/cppitertools`, or `share/cmake/cppitertools` as options.
Since other projects seemed to choose `share/${PROJECT_NAME}`, I figured
that was a fine option, as long as the default is not broken. Therefore,
this changes the default to
  share/cppitertools

Additionally, the old code didn't unconditionally put `cppitertools` at
the end of the config.version file, and so that was never being picked
up. Since it was unlikely that anyone was depending on the
config.version file being installed in the wrong location, we now
install it at the same place as the config file.

Fixes #72