### PR TITLE
Make operator* and operator-> const in all iterators.

### DIFF
--- a/batched.hpp
+++ b/batched.hpp
@@ -132,11 +132,11 @@ class iter::impl::Batcher {
              && (done() || !(sub_iter_ != other.sub_iter_));
     }
 
-    DerefVec<ContainerT>& operator*() {
+    DerefVec<ContainerT>& operator*() const {
       return *batch_;
     }
 
-    DerefVec<ContainerT>* operator->() {
+    DerefVec<ContainerT>* operator->() const {
       return batch_.get();
     }
   };

--- a/chain.hpp
+++ b/chain.hpp
@@ -1,16 +1,16 @@
 #ifndef ITER_CHAIN_HPP_
 #define ITER_CHAIN_HPP_
 
-#include "internal/iter_tuples.hpp"
-#include "internal/iterator_wrapper.hpp"
-#include "internal/iterbase.hpp"
-
 #include <array>
 #include <iterator>
 #include <optional>
 #include <tuple>
 #include <type_traits>
 #include <utility>
+
+#include "internal/iter_tuples.hpp"
+#include "internal/iterator_wrapper.hpp"
+#include "internal/iterbase.hpp"
 
 namespace iter {
   namespace impl {
@@ -62,12 +62,12 @@ class iter::impl::Chained {
     using ArrowType = iterator_arrow<std::tuple_element_t<0, TupTypeT>>;
 
     template <std::size_t Idx>
-    static DerefType get_and_deref(IterTupType& iters) {
+    static DerefType get_and_deref(const IterTupType& iters) {
       return *std::get<Idx>(iters);
     }
 
     template <std::size_t Idx>
-    static ArrowType get_and_arrow(IterTupType& iters) {
+    static ArrowType get_and_arrow(const IterTupType& iters) {
       return apply_arrow(std::get<Idx>(iters));
     }
 
@@ -82,8 +82,8 @@ class iter::impl::Chained {
       return std::get<Idx>(lhs) != std::get<Idx>(rhs);
     }
 
-    using DerefFunc = DerefType (*)(IterTupType&);
-    using ArrowFunc = ArrowType (*)(IterTupType&);
+    using DerefFunc = DerefType (*)(const IterTupType&);
+    using ArrowFunc = ArrowType (*)(const IterTupType&);
     using IncFunc = void (*)(IterTupType&);
     using NeqFunc = bool (*)(const IterTupType&, const IterTupType&);
 
@@ -137,11 +137,11 @@ class iter::impl::Chained {
       check_for_end_and_adjust();
     }
 
-    decltype(auto) operator*() {
+    decltype(auto) operator*() const {
       return IterData::derefers[index_](iters_);
     }
 
-    decltype(auto) operator-> () {
+    decltype(auto) operator->() const {
       return IterData::arrowers[index_](iters_);
     }
 
@@ -161,7 +161,7 @@ class iter::impl::Chained {
     bool operator!=(const Iterator& other) const {
       return index_ != other.index_
              || (index_ != sizeof...(Is)
-                    && IterData::neq_comparers[index_](iters_, other.iters_));
+                 && IterData::neq_comparers[index_](iters_, other.iters_));
     }
 
     bool operator==(const Iterator& other) const {
@@ -278,11 +278,11 @@ class iter::impl::ChainedFromIterable {
       return !(*this != other);
     }
 
-    iterator_deref<iterator_deref<ContainerT>> operator*() {
+    iterator_deref<iterator_deref<ContainerT>> operator*() const {
       return **sub_iter_p_;
     }
 
-    iterator_arrow<iterator_deref<ContainerT>> operator->() {
+    iterator_arrow<iterator_deref<ContainerT>> operator->() const {
       return apply_arrow(*sub_iter_p_);
     }
   };

--- a/chunked.hpp
+++ b/chunked.hpp
@@ -104,11 +104,11 @@ class iter::impl::Chunker {
              && (done() || !(sub_iter_ != other.sub_iter_));
     }
 
-    DerefVec<ContainerT>& operator*() {
+    DerefVec<ContainerT>& operator*() const {
       return *chunk_;
     }
 
-    DerefVec<ContainerT>* operator->() {
+    DerefVec<ContainerT>* operator->() const {
       return chunk_.get();
     }
   };

--- a/combinations.hpp
+++ b/combinations.hpp
@@ -43,7 +43,7 @@ class iter::impl::Combinator {
     friend class Iterator;
     constexpr static const int COMPLETE = -1;
     std::remove_reference_t<ContainerT>* container_p_;
-    CombIteratorDeref<ContainerT> indices_;
+    mutable CombIteratorDeref<ContainerT> indices_;
     int steps_{};
 
    public:
@@ -73,11 +73,11 @@ class iter::impl::Combinator {
       }
     }
 
-    CombIteratorDeref<ContainerT>& operator*() {
+    CombIteratorDeref<ContainerT>& operator*() const {
       return indices_;
     }
 
-    CombIteratorDeref<ContainerT>* operator->() {
+    CombIteratorDeref<ContainerT>* operator->() const {
       return &indices_;
     }
 

--- a/combinations_with_replacement.hpp
+++ b/combinations_with_replacement.hpp
@@ -43,7 +43,7 @@ class iter::impl::CombinatorWithReplacement {
     friend class Iterator;
     constexpr static const int COMPLETE = -1;
     std::remove_reference_t<ContainerT>* container_p_;
-    CombIteratorDeref<ContainerT> indices_;
+    mutable CombIteratorDeref<ContainerT> indices_;
     int steps_;
 
    public:
@@ -60,11 +60,11 @@ class iter::impl::CombinatorWithReplacement {
                      ? 0
                      : COMPLETE} {}
 
-    CombIteratorDeref<ContainerT>& operator*() {
+    CombIteratorDeref<ContainerT>& operator*() const {
       return indices_;
     }
 
-    CombIteratorDeref<ContainerT>* operator->() {
+    CombIteratorDeref<ContainerT>* operator->() const {
       return &indices_;
     }
 

--- a/compress.hpp
+++ b/compress.hpp
@@ -73,11 +73,11 @@ class iter::impl::Compressed {
       skip_failures();
     }
 
-    iterator_deref<ContainerT> operator*() {
+    iterator_deref<ContainerT> operator*() const {
       return *sub_iter_;
     }
 
-    iterator_arrow<ContainerT> operator->() {
+    iterator_arrow<ContainerT> operator->() const {
       return apply_arrow(sub_iter_);
     }
 

--- a/cycle.hpp
+++ b/cycle.hpp
@@ -52,11 +52,11 @@ class iter::impl::Cycler {
           sub_begin_{sub_iter},
           sub_end_{std::move(sub_end)} {}
 
-    iterator_deref<ContainerT> operator*() {
+    iterator_deref<ContainerT> operator*() const {
       return *sub_iter_;
     }
 
-    iterator_arrow<ContainerT> operator->() {
+    iterator_arrow<ContainerT> operator->() const {
       return apply_arrow(sub_iter_);
     }
 

--- a/dropwhile.hpp
+++ b/dropwhile.hpp
@@ -79,12 +79,12 @@ class iter::impl::Dropper {
           sub_end_{std::move(sub_end)},
           filter_func_(&filter_func) {}
 
-    typename Holder::reference operator*() {
+    typename Holder::reference operator*() const {
       init_if_first_use();
       return item_.get();
     }
 
-    typename Holder::pointer operator->() {
+    typename Holder::pointer operator->() const {
       init_if_first_use();
       return item_.get_ptr();
     }

--- a/enumerate.hpp
+++ b/enumerate.hpp
@@ -85,11 +85,11 @@ class iter::impl::Enumerable {
     Iterator(IteratorWrapper<ContainerT>&& sub_iter, Index start)
         : sub_iter_{std::move(sub_iter)}, index_{start} {}
 
-    IterYield<ContainerT> operator*() {
+    IterYield<ContainerT> operator*() const {
       return {index_, *sub_iter_};
     }
 
-    ArrowProxy<IterYield<ContainerT>> operator->() {
+    ArrowProxy<IterYield<ContainerT>> operator->() const {
       return {**this};
     }
 

--- a/filter.hpp
+++ b/filter.hpp
@@ -93,12 +93,12 @@ class iter::impl::Filtered {
           sub_end_{std::move(sub_end)},
           filter_func_(&filter_func) {}
 
-    typename Holder::reference operator*() {
+    typename Holder::reference operator*() const {
       init_if_first_use();
       return item_.get();
     }
 
-    typename Holder::pointer operator->() {
+    typename Holder::pointer operator->() const {
       init_if_first_use();
       return item_.get_ptr();
     }

--- a/internal/iterator_wrapper.hpp
+++ b/internal/iterator_wrapper.hpp
@@ -4,6 +4,7 @@
 #include <cassert>
 #include <functional>
 #include <variant>
+
 #include "iterbase.hpp"
 
 namespace iter {

--- a/permutations.hpp
+++ b/permutations.hpp
@@ -48,7 +48,7 @@ class iter::impl::Permuter {
       return *lhs < *rhs;
     }
 
-    Permutable<ContainerT> working_set_;
+    mutable Permutable<ContainerT> working_set_;
     int steps_{};
 
    public:
@@ -72,11 +72,11 @@ class iter::impl::Permuter {
           cmp_iters);
     }
 
-    Permutable<ContainerT>& operator*() {
+    Permutable<ContainerT>& operator*() const {
       return working_set_;
     }
 
-    Permutable<ContainerT>* operator->() {
+    Permutable<ContainerT>* operator->() const {
       return &working_set_;
     }
 

--- a/powerset.hpp
+++ b/powerset.hpp
@@ -82,11 +82,11 @@ class iter::impl::Powersetter {
       return ret;
     }
 
-    iterator_deref<CombinatorType<ContainerT>> operator*() {
+    iterator_deref<CombinatorType<ContainerT>> operator*() const {
       return *comb_iter_;
     }
 
-    iterator_arrow<CombinatorType<ContainerT>> operator->() {
+    iterator_arrow<CombinatorType<ContainerT>> operator->() const {
       apply_arrow(comb_iter_);
     }
 

--- a/product.hpp
+++ b/product.hpp
@@ -144,11 +144,11 @@ class iter::impl::Productor {
       return !(*this != other);
     }
 
-    TupleDeref<TupleTypeT> operator*() {
+    TupleDeref<TupleTypeT> operator*() const {
       return {(*std::get<Is>(iters_))...};
     }
 
-    auto operator->() -> ArrowProxy<decltype(**this)> {
+    auto operator->() const -> ArrowProxy<decltype(**this)> {
       return {**this};
     }
   };

--- a/reversed.hpp
+++ b/reversed.hpp
@@ -87,11 +87,11 @@ class iter::impl::Reverser {
     Iterator(ReverseIteratorWrapper<ContainerT>&& sub_iter)
         : sub_iter_{std::move(sub_iter)} {}
 
-    reverse_iterator_deref<ContainerT> operator*() {
+    reverse_iterator_deref<ContainerT> operator*() const {
       return *sub_iter_;
     }
 
-    reverse_iterator_arrow<ContainerT> operator->() {
+    reverse_iterator_arrow<ContainerT> operator->() const {
       return apply_arrow(sub_iter_);
     }
 

--- a/slice.hpp
+++ b/slice.hpp
@@ -62,11 +62,11 @@ class iter::impl::Sliced {
           stop_{stop},
           step_{step} {}
 
-    iterator_deref<ContainerT> operator*() {
+    iterator_deref<ContainerT> operator*() const {
       return *sub_iter_;
     }
 
-    iterator_arrow<ContainerT> operator->() {
+    iterator_arrow<ContainerT> operator->() const {
       return apply_arrow(sub_iter_);
     }
 

--- a/sliding_window.hpp
+++ b/sliding_window.hpp
@@ -76,11 +76,11 @@ class iter::impl::WindowSlider {
       return !(*this != other);
     }
 
-    DerefVec<ContainerT>& operator*() {
+    DerefVec<ContainerT>& operator*() const {
       return *window_;
     }
 
-    DerefVec<ContainerT>* operator->() {
+    DerefVec<ContainerT>* operator->() const {
       return window_.get();
     }
 

--- a/starmap.hpp
+++ b/starmap.hpp
@@ -84,11 +84,11 @@ class iter::impl::StarMapper {
       return ret;
     }
 
-    decltype(auto) operator*() {
+    decltype(auto) operator*() const {
       return std::apply(*func_, *sub_iter_);
     }
 
-    auto operator->() -> ArrowProxy<decltype(**this)> {
+    auto operator->() const -> ArrowProxy<decltype(**this)> {
       return {**this};
     }
   };
@@ -172,11 +172,11 @@ class iter::impl::TupleStarMapper {
     Iterator(Func& f, TupTypeT& t, std::size_t i)
         : func_{&f}, tup_{&t}, index_{i} {}
 
-    decltype(auto) operator*() {
+    decltype(auto) operator*() const {
       return IteratorData<TupTypeT>::callers[index_](*func_, *tup_);
     }
 
-    auto operator->() {
+    auto operator->() const {
       return ArrowProxy<decltype(**this)>{**this};
     }
 

--- a/takewhile.hpp
+++ b/takewhile.hpp
@@ -81,12 +81,12 @@ class iter::impl::Taker {
           sub_end_{std::move(sub_end)},
           filter_func_(&filter_func) {}
 
-    typename Holder::reference operator*() {
+    typename Holder::reference operator*() const {
       init_if_first_use();
       return item_.get();
     }
 
-    typename Holder::pointer operator->() {
+    typename Holder::pointer operator->() const {
       init_if_first_use();
       return item_.get_ptr();
     }

--- a/test/helpers.hpp
+++ b/test/helpers.hpp
@@ -65,7 +65,7 @@ namespace itertest {
       class Iterator {
        private:
         int i;
-        bool was_incremented = true;
+        mutable bool was_incremented = true;
 
        public:
         Iterator(int n) : i{n} {}
@@ -76,7 +76,7 @@ namespace itertest {
           return *this;
         }
 
-        int operator*() {
+        int operator*() const {
           if (!this->was_incremented) {
             throw DoubleDereferenceError{};
           }
@@ -175,7 +175,7 @@ namespace itertest {
         return *this;
       }
 
-      U& operator*() {
+      U& operator*() const {
         return *this->p;
       }
     };

--- a/zip.hpp
+++ b/zip.hpp
@@ -87,11 +87,11 @@ class iter::impl::Zipped {
       return !(*this != other);
     }
 
-    TupleDeref<TupleTypeT> operator*() {
+    TupleDeref<TupleTypeT> operator*() const {
       return {(*std::get<Is>(iters_))...};
     }
 
-    auto operator->() -> ArrowProxy<decltype(**this)> {
+    auto operator->() const -> ArrowProxy<decltype(**this)> {
       return {**this};
     }
   };

--- a/zip_longest.hpp
+++ b/zip_longest.hpp
@@ -97,13 +97,13 @@ class iter::impl::ZippedLongest {
       return !(*this != other);
     }
 
-    ZipIterDeref<TupleTypeT, OptTempl> operator*() {
+    ZipIterDeref<TupleTypeT, OptTempl> operator*() const {
       return {((std::get<Is>(iters_) != std::get<Is>(ends_))
                    ? OptTempl<Is, TupleTypeT>{*std::get<Is>(iters_)}
                    : OptTempl<Is, TupleTypeT>{})...};
     }
 
-    auto operator-> () -> ArrowProxy<decltype(**this)> {
+    auto operator-> () const -> ArrowProxy<decltype(**this)> {
       return {**this};
     }
   };


### PR DESCRIPTION
C++ iterators basically model pointers. Hence a const pointer can still be dereferenced to a mutable object (`T * const` *not* `const T*`). This is not true for many iterators in itertools since they only have non-`const` versions of `operator*`. This also violates C++ iterator concepts, see [the github issue](#91).

This change basically replaces all non-`const` dereference operators with `const` ones. This was straight forward in most cases:

- Some iterators own the data they return (note: that probably violates [`LegacyForwardIterator`](https://en.cppreference.com/w/cpp/named_req/ForwardIterator)). So those data fields were changed to `mutable`.
- `GroupBy` advances the group while dereferencing. This does not work when the iterator is constant. Moved the advancing to the constructor and increment operators. This is the only real behavior change, please review carefully.

Fixes #91 .