### PR TITLE
Add security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Policy
+
+If you have discovered a security vulnerability in this project, please report it
+privately. **Do not disclose it as a public issue.** This gives me time to work with you
+to fix the issue before public exposure, reducing the chance that the exploit will be
+used before a patch is released.
+
+You may submit the report in the following ways:
+
+- send an email to haining.cpp@gmail.com; and/or
+- send me a [private vulnerability report](https://github.com/ryanhaining/cppitertools/security/advisories/new)
+
+Please provide the following information in your report:
+
+- A description of the vulnerability and its impact
+- How to reproduce the issue
+
+This project is maintained by a single maintainer on a reasonable-effort basis. As such,
+I ask that you give me 90 days to work on a fix before public exposure.


### PR DESCRIPTION
Fixes #93.

This PR suggests a security policy. It currently suggests reporting either via email (using the address taken from the [conanfile.py](https://github.com/ryanhaining/cppitertools/blob/master/conanfile.py)) or using GitHub's vuln reporting feature.

If you'd rather use just one of these (or something else entirely), let me know and I'll modify the policy as needed.