### PR TITLE
compare const and non-const chained iterators

### DIFF
--- a/chain.hpp
+++ b/chain.hpp
@@ -1,16 +1,16 @@
 #ifndef ITER_CHAIN_HPP_
 #define ITER_CHAIN_HPP_
 
-#include "internal/iter_tuples.hpp"
-#include "internal/iterator_wrapper.hpp"
-#include "internal/iterbase.hpp"
-
 #include <array>
 #include <iterator>
 #include <optional>
 #include <tuple>
 #include <type_traits>
 #include <utility>
+
+#include "internal/iter_tuples.hpp"
+#include "internal/iterator_wrapper.hpp"
+#include "internal/iterbase.hpp"
 
 namespace iter {
   namespace impl {
@@ -42,6 +42,26 @@ template <typename TupType, std::size_t... Is>
 class iter::impl::Chained {
  private:
   friend ChainMaker;
+
+  template <typename TupTypeTA, typename TupTypeTB>
+  class IteratorDataPair {
+    IteratorDataPair() = delete;
+
+   public:
+    using IterTupTypeA = iterator_tuple_type<TupTypeTA>;
+    using IterTupTypeB = iterator_tuple_type<TupTypeTB>;
+
+    template <std::size_t Idx>
+    static bool get_and_check_not_equal(
+        const IterTupTypeA& lhs, const IterTupTypeB& rhs) {
+      return std::get<Idx>(lhs) != std::get<Idx>(rhs);
+    }
+
+    using NeqFunc = bool (*)(const IterTupTypeA&, const IterTupTypeB&);
+
+    constexpr static std::array<NeqFunc, sizeof...(Is)> neq_comparers{
+        {get_and_check_not_equal<Is>...}};
+  };
 
   template <typename TupTypeT>
   class IteratorData {
@@ -76,16 +96,9 @@ class iter::impl::Chained {
       ++std::get<Idx>(iters);
     }
 
-    template <std::size_t Idx>
-    static bool get_and_check_not_equal(
-        const IterTupType& lhs, const IterTupType& rhs) {
-      return std::get<Idx>(lhs) != std::get<Idx>(rhs);
-    }
-
     using DerefFunc = DerefType (*)(IterTupType&);
     using ArrowFunc = ArrowType (*)(IterTupType&);
     using IncFunc = void (*)(IterTupType&);
-    using NeqFunc = bool (*)(const IterTupType&, const IterTupType&);
 
     constexpr static std::array<DerefFunc, sizeof...(Is)> derefers{
         {get_and_deref<Is>...}};
@@ -95,9 +108,6 @@ class iter::impl::Chained {
 
     constexpr static std::array<IncFunc, sizeof...(Is)> incrementers{
         {get_and_increment<Is>...}};
-
-    constexpr static std::array<NeqFunc, sizeof...(Is)> neq_comparers{
-        {get_and_check_not_equal<Is>...}};
 
     using TraitsValue =
         iterator_traits_deref<std::tuple_element_t<0, TupTypeT>>;
@@ -119,12 +129,16 @@ class iter::impl::Chained {
 
     void check_for_end_and_adjust() {
       while (index_ < sizeof...(Is)
-             && !(IterData::neq_comparers[index_](iters_, ends_))) {
+             && !(IteratorDataPair<TupTypeT, TupTypeT>::neq_comparers[index_](
+                 iters_, ends_))) {
         ++index_;
       }
     }
 
    public:
+    template <typename>
+    friend class Iterator;
+
     using iterator_category = std::input_iterator_tag;
     using value_type = typename IteratorData<TupTypeT>::TraitsValue;
     using difference_type = std::ptrdiff_t;
@@ -141,7 +155,7 @@ class iter::impl::Chained {
       return IterData::derefers[index_](iters_);
     }
 
-    decltype(auto) operator-> () {
+    decltype(auto) operator->() {
       return IterData::arrowers[index_](iters_);
     }
 
@@ -158,13 +172,16 @@ class iter::impl::Chained {
     }
 
     // TODO make const and non-const iterators comparable
-    bool operator!=(const Iterator& other) const {
+    template <typename T>
+    bool operator!=(const Iterator<T>& other) const {
       return index_ != other.index_
              || (index_ != sizeof...(Is)
-                    && IterData::neq_comparers[index_](iters_, other.iters_));
+                 && IteratorDataPair<TupTypeT, T>::neq_comparers[index_](
+                     iters_, other.iters_));
     }
 
-    bool operator==(const Iterator& other) const {
+    template <typename T>
+    bool operator==(const Iterator<T>& other) const {
       return !(*this != other);
     }
   };

--- a/chain.hpp
+++ b/chain.hpp
@@ -171,7 +171,6 @@ class iter::impl::Chained {
       return ret;
     }
 
-    // TODO make const and non-const iterators comparable
     template <typename T>
     bool operator!=(const Iterator<T>& other) const {
       return index_ != other.index_

--- a/test/test_chain.cpp
+++ b/test/test_chain.cpp
@@ -1,6 +1,4 @@
 #include <chain.hpp>
-#include "helpers.hpp"
-
 #include <iterator>
 #include <list>
 #include <string>
@@ -8,6 +6,7 @@
 #include <vector>
 
 #include "catch.hpp"
+#include "helpers.hpp"
 
 using iter::chain;
 using itertest::BasicIterable;
@@ -37,14 +36,12 @@ TEST_CASE("chain: const iteration", "[chain][const]") {
   REQUIRE(v == vc);
 }
 
-// TODO make this work
-#if 0
-TEST_CASE("chain: const iterators can be compared to non-const itertors", "[chain][const]") {
+TEST_CASE("chain: const iterators can be compared to non-const itertors",
+    "[chain][const]") {
   auto ch = chain(std::string{}, std::string{});
   const auto& cch = ch;
   (void)(std::begin(ch) == std::end(cch));
 }
-#endif
 
 TEST_CASE("chain: with different container types", "[chain]") {
   std::string s1{"abc"};

--- a/test/test_chain.cpp
+++ b/test/test_chain.cpp
@@ -38,9 +38,31 @@ TEST_CASE("chain: const iteration", "[chain][const]") {
 
 TEST_CASE("chain: const iterators can be compared to non-const itertors",
     "[chain][const]") {
-  auto ch = chain(std::string{}, std::string{});
-  const auto& cch = ch;
-  (void)(std::begin(ch) == std::end(cch));
+  std::string s1{"abc"};
+  std::list<char> li{'m', 'n', 'o'};
+  auto ch = chain(s1, li);
+
+  const auto cch = chain(s1, li);
+  SECTION("begin and const begin compare equal") {
+    REQUIRE(std::begin(ch) == std::begin(cch));
+  }
+  SECTION("begin and const end compare not-equal") {
+    REQUIRE_FALSE(std::begin(ch) == std::end(cch));
+  }
+  SECTION("end and const end compare equal") {
+    REQUIRE(std::end(ch) == std::end(cch));
+  }
+  SECTION(
+      "const and non-const iterator compare equal/not-equal at appropriate "
+      "pos.") {
+    auto iter = ch.begin();
+    iter++;
+    auto citer = cch.begin();
+    citer++;
+    REQUIRE(iter == citer);
+    citer++;
+    REQUIRE_FALSE(iter == citer);
+  }
 }
 
 TEST_CASE("chain: with different container types", "[chain]") {
@@ -215,10 +237,32 @@ TEST_CASE(
     "chain.from_iterable: const iterators can be compared to non-const "
     "iterators",
     "[chain.from_iterable][const]") {
-  std::vector<std::vector<int>> v{};
+  std::vector<std::vector<int>> v{{1, 2}, {4, 6}};
   auto ch = chain.from_iterable(v);
   const auto& cch = ch;
-  (void)(std::begin(ch) == std::end(cch));
+
+  SECTION("begin and const end compare not-equal") {
+    REQUIRE_FALSE(std::begin(ch) == std::end(cch));
+  }
+  SECTION("begin and const begin compare equal") {
+    REQUIRE(std::begin(ch) == std::begin(cch));
+  }
+  SECTION("end and const end compare not-equal") {
+    REQUIRE(std::end(ch) == std::end(cch));
+  }
+  SECTION(
+      "const and non-const iterator compare equal/not-equal at appropriate "
+      "pos.") {
+    auto iter = ch.begin();
+    iter++;
+    auto citer = cch.begin();
+    citer++;
+    REQUIRE(iter == citer);
+    citer++;
+    REQUIRE_FALSE(iter == citer);
+    iter++;
+    REQUIRE(iter == citer);
+  }
 }
 
 TEST_CASE("chain.fromm_iterable: Works with different begin and end types",


### PR DESCRIPTION
There is new struct called `IteratorDataPair` templated on 2 tuple-like types. This enables binary operations to have different tuple-like types.

`check_end_and_adjust()` effectively is a unary operation, but we can simply pass the same type twice.

Also I just friended any `Iterator<T>` with another `Iterator<K>` for easy access to `index_`